### PR TITLE
Fix Swift project handling

### DIFF
--- a/lib/deliver/ipa_uploader.rb
+++ b/lib/deliver/ipa_uploader.rb
@@ -135,7 +135,7 @@ module Deliver
       def fetch_info_plist_file
         Zip::File.open(@ipa_file.path) do |zipfile|
           zipfile.each do |file|
-            if file.name.include?'.plist' and not file.name.include?".bundle"
+            if file.name.include?'.plist' and not ['.bundle', '.framework'].any? { |a| file.name.include?a }
               # We can not be completely sure, that's the correct plist file, so we have to try
               begin
                 # The XML file has to be properly unpacked first


### PR DESCRIPTION
Swift project may bundle additional ".framework" bundles, make sure to not search them while looking for the application's Info.plist file.
