### PR TITLE
Fix some typos

### DIFF
--- a/lib/deliver/app_metadata.rb
+++ b/lib/deliver/app_metadata.rb
@@ -1,9 +1,9 @@
 require 'nokogiri'
 
 module Deliver
-  class AppMetadataError < StandardError 
+  class AppMetadataError < StandardError
   end
-  class AppMetadataParameterError < StandardError 
+  class AppMetadataParameterError < StandardError
   end
 
   class AppMetadata
@@ -40,7 +40,7 @@ module Deliver
     # @param app [Deliver::App] The app this metadata is from/for
     # @param dir [String] The app this metadata is from/for
     # @param redownload_package [bool] When true
-    #  the current package will be downloaded from iTC before you can 
+    #  the current package will be downloaded from iTC before you can
     #  modify any values. This should only be false for unit tests
     # @raise (AppMetadataParameterError) Is thrown when don't pass a correct app object
     def initialize(app, dir, redownload_package = true)
@@ -93,10 +93,10 @@ module Deliver
         Helper.log.info("Locale '#{language}' already exists. Can not create it again.")
         return false
       end
-      
+
 
       locales = fetch_value("//x:locales").first
-      
+
       new_locale = @data.create_element('locale')
       new_locale['name'] = language
       locales << new_locale
@@ -110,7 +110,7 @@ module Deliver
 
       Helper.log.info("Successfully created the new locale '#{language}'. The default title '#{default_title}' was set, since it's required by iTunesConnect.")
       Helper.log.info("You can update the title using 'app.metadata.update_title'")
-      
+
       information[language] ||= {}
       information[language][:title] = { value: default_title, modified: true}
 
@@ -218,14 +218,14 @@ module Deliver
 
     def add_screenshot(language, app_screenshot)
       raise AppMetadataParameterError.new(INVALID_LANGUAGE_ERROR) unless Languages::ALL_LANGUAGES.include?language
-      
+
       create_locale_if_not_exists(language)
 
       # Fetch the 'software_screenshots' node (array) for the specific locale
       locales = self.fetch_value("//x:locale[@name='#{language}']")
 
       screenshots = self.fetch_value("//x:locale[@name='#{language}']/x:software_screenshots").first
-      
+
       if not screenshots or screenshots.children.count == 0
         screenshots.remove if screenshots
 
@@ -277,7 +277,7 @@ module Deliver
 
       new_screenshots.each do |key, value|
         if key.kind_of?String and value.kind_of?Array and value.count > 0 and value.first.kind_of?AppScreenshot
-          
+
           self.clear_all_screenshots(key)
 
           value.each do |screen|
@@ -291,9 +291,9 @@ module Deliver
     end
 
     # Automatically add all screenshots contained in the given directory to the app.
-    # 
+    #
     # This method will automatically detect which device type each screenshot is.
-    # 
+    #
     # This will also clear all existing screenshots before setting the new ones.
     # @param (Hash) hash A hash containing a different path for each locale ({Deliver::Languages::ALL_LANGUAGES})
     def set_screenshots_for_each_language(hash)
@@ -305,10 +305,10 @@ module Deliver
         raise AppMetadataParameterError.new(INVALID_LANGUAGE_ERROR) unless Languages::ALL_LANGUAGES.include?language
 
         if Dir[resulting_path].count == 0
-          Helper.log.error("No screenshots found at the given path '#{resulting_path}'") 
+          Helper.log.error("No screenshots found at the given path '#{resulting_path}'")
         else
           self.clear_all_screenshots(language)
-          
+
           Dir[resulting_path].sort.each do |path|
             add_screenshot(language, Deliver::AppScreenshot.new(path))
           end
@@ -318,7 +318,7 @@ module Deliver
       true
     end
 
-    # This method will run through all the available locales, check if there is 
+    # This method will run through all the available locales, check if there is
     # a folder for this language (e.g. 'en-US') and use all screenshots in there
     # @param (String) path A path to the folder, which contains a folder for each locale
     def set_all_screenshots_from_path(path)
@@ -383,7 +383,7 @@ module Deliver
         end
       end
 
-      # @return (Deliver::ItunesTransporter) The iTunesTranspoter which is
+      # @return (Deliver::ItunesTransporter) The iTunesTransporter which is
       #  used to upload/download the app metadata.
       def transporter
         @transporter ||= ItunesTransporter.new
@@ -402,7 +402,7 @@ module Deliver
           locale = fetch_value("//x:locale[@name='#{language}']").first
 
           raise AppMetadataParameterError.new("#{INVALID_LANGUAGE_ERROR} (#{language})") unless Languages::ALL_LANGUAGES.include?language
-          
+
 
           field = locale.search(xpath_name).first
 
@@ -475,7 +475,7 @@ module Deliver
               modified: false
             }
           end
-          
+
           information[language][:keywords] = { value: [], modified: false}
           locale.search('keyword').each do |current|
             information[language][:keywords][:value] << current.content

--- a/lib/deliver/itunes_transporter.rb
+++ b/lib/deliver/itunes_transporter.rb
@@ -5,7 +5,7 @@ require 'deliver/password_manager'
 
 module Deliver
   # The TransporterInputError occurs when you passed wrong inputs to the {Deliver::ItunesTransporter}
-  class TransporterInputError < StandardError 
+  class TransporterInputError < StandardError
   end
   # The TransporterTransferError occurs when some error happens
   # while uploading or downloading something from/to iTC
@@ -13,18 +13,18 @@ module Deliver
   end
 
   class ItunesTransporter
-    ERROR_REGEX = />\s*ERROR:\s+(.+)/  
+    ERROR_REGEX = />\s*ERROR:\s+(.+)/
     WARNING_REGEX = />\s*WARN:\s+(.+)/
     OUTPUT_REGEX = />\s+(.+)/
 
     private_constant :ERROR_REGEX, :WARNING_REGEX, :OUTPUT_REGEX
 
-    # This will be called from the Deliverfile, and disables the logging of the transpoter output
+    # This will be called from the Deliverfile, and disables the logging of the transporter output
     def self.hide_transporter_output
       @@hide_transporter_output = true
     end
-    
-    # Returns a new instance of the iTunesTranspoter.
+
+    # Returns a new instance of the iTunesTransporter.
     # If no username or password given, it will be taken from
     # the #{Deliver::PasswordManager}
     def initialize(user = nil, password = nil)
@@ -73,7 +73,7 @@ module Deliver
       dir += "/#{app.apple_id}.itmsp"
 
       Helper.log.info "Going to upload updated app to iTunesConnect"
-      
+
       command = build_upload_command(@user, @password, dir)
       result = execute_transporter(command)
 
@@ -91,7 +91,7 @@ module Deliver
 
         if defined?@@hide_transporter_output
           # Show a one time message instead
-          Helper.log.info "Waiting for iTunes Connect transpoter to be finished.".green
+          Helper.log.info "Waiting for iTunes Connect transporter to be finished.".green
           Helper.log.info "If you want upload/download logs to be enabled, remove 'hide_transporter_output' from your Deliverfile."
           Helper.log.info "iTunes Transporter progress...".green
         end
@@ -137,7 +137,7 @@ module Deliver
 
         if not defined?@@hide_transporter_output and line =~ OUTPUT_REGEX
           # General logging for debug purposes
-          Helper.log.debug "[Transpoter Output]: #{$1}"
+          Helper.log.debug "[Transporter Output]: #{$1}"
         end
       end
 


### PR DESCRIPTION
I noticed the use of “transpoter” in some places, instead of “transporter”. This commit fixes that.
