### PR TITLE
don't check encryption updated radio when version 1.0

### DIFF
--- a/lib/deliver/ipa_uploader.rb
+++ b/lib/deliver/ipa_uploader.rb
@@ -107,7 +107,7 @@ module Deliver
         # Publish onto Production
         Helper.log.info "Putting the latest build onto production."
         if self.app.itc.put_build_into_production!(self.app, self.fetch_app_version)
-          if self.app.itc.submit_for_review!(self.app, submit_information, self.fetch_app_version)
+          if self.app.itc.submit_for_review!(self.app, submit_information)
             Helper.log.info "Successfully deployed a new update of your app. You can now enjoy a good cold Club Mate.".green
             return true
           end

--- a/lib/deliver/ipa_uploader.rb
+++ b/lib/deliver/ipa_uploader.rb
@@ -107,7 +107,7 @@ module Deliver
         # Publish onto Production
         Helper.log.info "Putting the latest build onto production."
         if self.app.itc.put_build_into_production!(self.app, self.fetch_app_version)
-          if self.app.itc.submit_for_review!(self.app, submit_information)
+          if self.app.itc.submit_for_review!(self.app, submit_information, self.fetch_app_version)
             Helper.log.info "Successfully deployed a new update of your app. You can now enjoy a good cold Club Mate.".green
             return true
           end

--- a/lib/deliver/itunes_connect.rb
+++ b/lib/deliver/itunes_connect.rb
@@ -369,7 +369,7 @@ module Deliver
     # This can easily cause exceptions, which will be shown on iTC.
     # @param app (Deliver::App) the app you want to submit
     # @param perms (Hash) information about content rights, ...
-    def submit_for_review!(app, perms = nil)
+    def submit_for_review!(app, perms = nil, version_number)
       begin
         verify_app(app)
         open_app_page(app)
@@ -422,7 +422,7 @@ module Deliver
             end
 
             begin
-              first(:xpath, "#{basic}.exportCompliance.encryptionUpdated.value' and @radio-value='#{perms[:export_compliance][:encryption_updated]}']//input").trigger('click')
+              first(:xpath, "#{basic}.exportCompliance.encryptionUpdated.value' and @radio-value='#{perms[:export_compliance][:encryption_updated]}']//input").trigger('click') unless version_number == "1.0"
               first(:xpath, "#{basic}.exportCompliance.usesEncryption.value' and @radio-value='#{perms[:export_compliance][:cryptography_enabled]}']//input").trigger('click')
               first(:xpath, "#{basic}.exportCompliance.isExempt.value' and @radio-value='#{perms[:export_compliance][:is_exempt]}']//input").trigger('click')
             rescue

--- a/lib/deliver/itunes_connect.rb
+++ b/lib/deliver/itunes_connect.rb
@@ -369,7 +369,7 @@ module Deliver
     # This can easily cause exceptions, which will be shown on iTC.
     # @param app (Deliver::App) the app you want to submit
     # @param perms (Hash) information about content rights, ...
-    def submit_for_review!(app, perms = nil, version_number)
+    def submit_for_review!(app, perms = nil)
       begin
         verify_app(app)
         open_app_page(app)

--- a/lib/deliver/itunes_connect.rb
+++ b/lib/deliver/itunes_connect.rb
@@ -418,13 +418,12 @@ module Deliver
           #####################
           if page.has_content?"Export"
             
-            encryption_updated_control = all(:xpath, "#{basic}.exportCompliance.encryptionUpdated.value' and @radio-value='#{perms[:export_compliance][:encryption_updated]}']//input")
-            
             if not perms[:export_compliance][:encryption_updated] and perms[:export_compliance][:cryptography_enabled]
               raise "encryption_updated must be enabled if cryptography_enabled is enabled!"
             end
 
             begin
+              encryption_updated_control = all(:xpath, "#{basic}.exportCompliance.encryptionUpdated.value' and @radio-value='#{perms[:export_compliance][:encryption_updated]}']//input")
               encryption_updated_control[0].trigger('click') if encryption_updated_control.count > 0
               first(:xpath, "#{basic}.exportCompliance.usesEncryption.value' and @radio-value='#{perms[:export_compliance][:cryptography_enabled]}']//input").trigger('click')
               first(:xpath, "#{basic}.exportCompliance.isExempt.value' and @radio-value='#{perms[:export_compliance][:is_exempt]}']//input").trigger('click')

--- a/lib/deliver/itunes_connect.rb
+++ b/lib/deliver/itunes_connect.rb
@@ -417,12 +417,15 @@ module Deliver
           # Export Compliance #
           #####################
           if page.has_content?"Export"
+            
+            encryption_updated_control = all(:xpath, "#{basic}.exportCompliance.encryptionUpdated.value' and @radio-value='#{perms[:export_compliance][:encryption_updated]}']//input")
+            
             if not perms[:export_compliance][:encryption_updated] and perms[:export_compliance][:cryptography_enabled]
               raise "encryption_updated must be enabled if cryptography_enabled is enabled!"
             end
 
             begin
-              first(:xpath, "#{basic}.exportCompliance.encryptionUpdated.value' and @radio-value='#{perms[:export_compliance][:encryption_updated]}']//input").trigger('click') unless version_number == "1.0"
+              encryption_updated_control[0].trigger('click') if encryption_updated_control.count > 0
               first(:xpath, "#{basic}.exportCompliance.usesEncryption.value' and @radio-value='#{perms[:export_compliance][:cryptography_enabled]}']//input").trigger('click')
               first(:xpath, "#{basic}.exportCompliance.isExempt.value' and @radio-value='#{perms[:export_compliance][:is_exempt]}']//input").trigger('click')
             rescue


### PR DESCRIPTION
Hey there,

This is what I'm thinking to address version 1.0 apps. In our scenarios we're trying to automate not only updates but also version 1.0 apps.

I haven't added tests yet, would like too but first wanted to illustrate the issue I'm facing.

Brent
