### PR TITLE
Feature/idfa support

### DIFF
--- a/lib/deliver/itunes_connect.rb
+++ b/lib/deliver/itunes_connect.rb
@@ -414,7 +414,7 @@ module Deliver
               attribute_advertisement: false,
               attribute_actions: false,
               limit_ad_tracking: false
-	    	}
+            }
           }
 
           basic = "//*[@itc-radio='submitForReviewAnswers"

--- a/lib/deliver/itunes_connect.rb
+++ b/lib/deliver/itunes_connect.rb
@@ -408,7 +408,13 @@ module Deliver
               contains_third_party_content: false,
               has_rights: false
             },
-            advertising_identifier: false
+            advertising_identifier: {
+              use_idfa: false,
+			  serve_advertisement: false,
+	  	      attribute_advertisement: false,
+	  	      attribute_actions: false,
+	  	      limit_ad_tracking: false
+	    	}
           }
 
           basic = "//*[@itc-radio='submitForReviewAnswers"
@@ -460,7 +466,7 @@ module Deliver
 				if perms[:advertising_identifier][:attribute_advertisement]
 					first(:xpath, "#{checkbox}.adIdInfo.tracksInstall.value']//a").click
 				end
-				if perms[:advertising_identifier][:attribut_actions]
+				if perms[:advertising_identifier][:attribute_actions]
 					first(:xpath, "#{checkbox}.adIdInfo.tracksAction.value']//a").click
 				end
 				if perms[:advertising_identifier][:limit_ad_tracking]

--- a/lib/deliver/itunes_connect.rb
+++ b/lib/deliver/itunes_connect.rb
@@ -412,6 +412,7 @@ module Deliver
           }
 
           basic = "//*[@itc-radio='submitForReviewAnswers"
+          checkbox = "//*[@itc-checkbox='submitForReviewAnswers"
 
           #####################
           # Export Compliance #
@@ -450,10 +451,21 @@ module Deliver
           # Advertising Identifier #
           ##########################
           if page.has_content?"Advertising Identifier"
-            first(:xpath, "#{basic}.adIdInfo.usesIdfa.value' and @radio-value='#{perms[:advertising_identifier]}']//input").trigger('click') rescue nil
+            first(:xpath, "#{basic}.adIdInfo.usesIdfa.value' and @radio-value='#{perms[:advertising_identifier][:use_idfa]}']//a").click rescue nil
 
-            if perms[:advertising_identifier]
-              raise "Sorry, the advertising_identifier menu is not yet supported. Open '#{current_url}' in your browser and manually submit the app".red
+            if perms[:advertising_identifier][:use_idfa]
+				if perms[:advertising_identifier][:serve_advertisement]
+					first(:xpath, "#{checkbox}.adIdInfo.servesAds.value']//a").click
+				end
+				if perms[:advertising_identifier][:attribute_advertisement]
+					first(:xpath, "#{checkbox}.adIdInfo.tracksInstall.value']//a").click
+				end
+				if perms[:advertising_identifier][:attribut_actions]
+					first(:xpath, "#{checkbox}.adIdInfo.tracksAction.value']//a").click
+				end
+				if perms[:advertising_identifier][:limit_ad_tracking]
+					first(:xpath, "#{checkbox}.adIdInfo.limitsTracking.value']//a").click
+				end
             end
           end
           

--- a/lib/deliver/itunes_connect.rb
+++ b/lib/deliver/itunes_connect.rb
@@ -410,10 +410,10 @@ module Deliver
             },
             advertising_identifier: {
               use_idfa: false,
-			  serve_advertisement: false,
-	  	      attribute_advertisement: false,
-	  	      attribute_actions: false,
-	  	      limit_ad_tracking: false
+              serve_advertisement: false,
+              attribute_advertisement: false,
+              attribute_actions: false,
+              limit_ad_tracking: false
 	    	}
           }
 


### PR DESCRIPTION
Hi Felix,
I've implemented IDFA options support during submitting app into review.
Could you please add this commit in to deliver?
It also makes sense to update example of submit_information
I use this structure:
submit_further_information = {
      export_compliance: {
        encryption_updated: false,
        cryptography_enabled: false,
        is_exempt: false
      },
      third_party_content: {
        contains_third_party_content: true,
        has_rights: true
      },
      advertising_identifier: {
        use_idfa: true,
        serve_advertisement: true,
        attribute_advertisement: true,
        attribute_actions: true,
        limit_ad_tracking: true
      },
  }

Thank you for the great tool!

Cheers,
Oleksii
