### PR TITLE
Update language code for zh-CN at readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,7 +283,7 @@ Before actually uploading anything to iTunes, ```Deliver``` will generate a [PDF
 
 ## Available language codes
 ```ruby
-["da-DK", "de-DE", "el-GR", "en-AU", "en-CA", "en-GB", "en-US", "es-ES", "es-MX", "fi-FI", "fr-CA", "fr-FR", "id-ID", "it-IT", "ja-JP", "ko-KR", "ms-MY", "nl-NL", "no-NO", "pt-BR", "pt-PT", "ru-RU", "sv-SE", "th-TH", "tr-TR", "vi-VI", "cmn-Hans", "zh_CN", "cmn-Hant"]
+["da-DK", "de-DE", "el-GR", "en-AU", "en-CA", "en-GB", "en-US", "es-ES", "es-MX", "fi-FI", "fr-CA", "fr-FR", "id-ID", "it-IT", "ja-JP", "ko-KR", "ms-MY", "nl-NL", "no-NO", "pt-BR", "pt-PT", "ru-RU", "sv-SE", "th-TH", "tr-TR", "vi-VI", "cmn-Hans", "zh-CN", "cmn-Hant"]
 ```
 
 ## Use a clean status bar


### PR DESCRIPTION
I've used the language codes of the readme to generate my json, and I haven't seen that zh-CN language had the iso code with underscore. On deliver it to ITC, I had an error of metadata.xml malformed:

```
ERROR [2015-01-17 12:16:33.86]: [Transporter Error Output]: ERROR ITMS-3000: "Line 402 column 5288: value of attribute "name" is invalid; must be a string matching the regular expression "[a-zA-Z]{2,3}(-[a-zA-Z]{4})?(-([0-9]{3}|[a-zA-Z]{2}))?" at XPath /package/software/software_metadata/versions/version/locales/locale[27]"
DEBUG [2015-01-17 12:16:33.86]: [Transporter Output]: DBG-X: The error code is: 1102
FATAL [2015-01-17 12:16:33.97]: Transporter transfer failed.
```

It was due to have at my json zh_CN instead of zh-CN

So just in case anyone use the language codes as I've done, it's better to fix that code at the readme to the Apple ones.

Maybe as an idea, it would be great to validate the language codes at metadata.json, but I don't think it is a common error, so it is not a "must have". 
I would add this validation at this pull request, but I've never make anything with ruby (may be it's a good moment to try it... :P).
