### PR TITLE
[WIP] Automatically fetching of existing screenshots and storing in screenshots

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,8 +129,6 @@ The guide will create all the necessary files for you, using the existing app me
  - Enjoy a good drink, while the computer does all the work for you
 - When it's a new app: ```n```
 
-Copy your screenshots into the ```deliver/screenshots/[language]``` folders (see [Available language codes](#available-language-codes))
-
 From now on, you can run ```deliver``` to deploy a new update, or just upload new app metadata and screenshots.
 
 ### Customize the ```Deliverfile```

--- a/lib/assets/DeliverLanguageMapping.json
+++ b/lib/assets/DeliverLanguageMapping.json
@@ -1,0 +1,167 @@
+[
+ {
+  "locale": "cmn-Hans",
+  "name": "Simplified Chinese",
+  "game-center": true
+
+  },
+  {
+  "locale": "cmn-Hant",
+  "name": "Traditional Chinese",
+  "game-center": true
+  },
+  {
+  "locale": "da-DK",
+  "name": "Danish",
+  "game-center": true,
+  "alternatives": ["da"]
+  },
+  {
+  "locale": "nl-NL",
+  "name": "Dutch",
+ "game-center": true,
+ "alternatives": ["nl"]
+  },
+  {
+  "locale": "en-AU",
+  "name": "Australian English",
+  "game-center": false,
+  "readable-alternatives": ["English_Australian"]
+  },
+  {
+  "locale": "en-CA",
+  "name": "Canadian English",
+  "game-center": false,
+  "readable-alternatives": ["English_CA"]
+  },
+  {
+  "locale": "en-GB",
+  "name": "UK English",
+  "game-center": true,
+  "readable-alternatives": ["English_UK"]
+  },
+  {
+  "locale": "en-US",
+  "name": "English",
+  "game-center": true
+  },
+  {
+  "locale": "fi-FI",
+  "name": "Finnish",
+  "game-center": true,
+  "alternatives": ["fi"]
+  },
+  {
+  "locale": "fr-CA",
+  "name": "Canadian French",
+  "game-center": false,
+  "readable-alternatives": ["French_CA"]
+  },
+  {
+  "locale": "fr-FR",
+  "name": "French",
+ "game-center": true,
+ "alternatives": ["fr"]
+  },
+  {
+  "locale": "de-DE",
+  "name": "German",
+  "game-center": true,
+  "alternatives": ["de"]
+  },
+  {
+  "locale": "el-GR",
+  "name": "Greek",
+ "game-center": true,
+ "alternatives": ["el"]
+  },
+  {
+  "locale": "id-ID",
+  "name": "Indonesian",
+ "game-center": true,
+ "alternatives": ["id"]
+  },
+  {
+  "locale": "it-IT",
+  "name": "Italian",
+ "game-center": true,
+ "alternatives": ["it"]
+  },
+  {
+  "locale": "ja-JP",
+  "name": "Japanese",
+ "game-center": true,
+ "alternatives": ["ja"]
+  },
+  {
+  "locale": "ko-KR",
+  "name": "Korean",
+ "game-center": true,
+ "alternatives": ["ko"]
+  },
+  {
+  "locale": "ms-MY",
+  "name": "Malay",
+ "game-center": true,
+ "alternatives": ["ms"]
+  },
+  {
+  "locale": "no-NO",
+  "name": "Norwegian",
+ "game-center": true,
+ "alternatives": ["no"]
+  },
+  {
+  "locale": "pt-BR",
+  "name": "Brazilian Portuguese",
+  "game-center": true
+  },
+  {
+  "locale": "pt-PT",
+  "name": "Portuguese",
+  "game-center": true,
+ "alternatives": ["pt"]
+  },
+  {
+  "locale": "ru-RU",
+  "name": "Russian",
+ "game-center": true,
+ "alternatives": ["ru"]
+  },
+  {
+  "locale": "es-MX",
+  "name": "Mexican Spanish",
+  "game-center": false,
+  "readable-alternatives": ["Spanish_MX"]
+  },
+  {
+  "locale": "es-ES",
+  "name": "Spanish",
+  "game-center": true,
+  "alternatives": ["es"]
+  },
+  {
+  "locale": "sv-SE",
+  "name": "Swedish",
+ "game-center": true,
+ "alternatives": ["sv"]
+  },
+  {
+  "locale": "th-TH",
+  "name": "Thai",
+ "game-center": true,
+ "alternatives": ["th"]
+  },
+  {
+  "locale": "tr-TR",
+  "name": "Turkish",
+ "game-center": true,
+ "alternatives": ["tr"]
+  },
+  {
+  "locale": "vi-VI",
+  "name" : "Vietnamese",
+ "game-center": true,
+ "alternatives": ["vi"]
+  }
+  ]

--- a/lib/assets/DeliverfileDefault
+++ b/lib/assets/DeliverfileDefault
@@ -12,7 +12,7 @@
 # This folder has to include one folder for each language
 # More information about automatic screenshot upload: 
 # https://github.com/KrauseFx/deliver#upload-screenshots-to-itunes-connect
-screenshots_path "./deliver/screenshots/"
+screenshots_path "./screenshots/"
 
 
 # version '1.2' # you can pass this if you want to verify the version number with the ipa file

--- a/lib/deliver/deliverfile/deliverfile_creator.rb
+++ b/lib/deliver/deliverfile/deliverfile_creator.rb
@@ -1,5 +1,6 @@
 require 'credentials_manager/password_manager'
 require 'credentials_manager/appfile_config'
+require 'deliver/itunes_connect/itunes_connect'
 
 module Deliver
   # Helps new user quickly adopt Deliver
@@ -45,8 +46,6 @@ module Deliver
       example.gsub!("[[APP_NAME]]", project_name)
       File.write(path, example)
 
-      FileUtils.mkdir_p './screenshots/'
-
       puts "Successfully created new Deliverfile at '#{path}'".green
     end
 
@@ -62,6 +61,9 @@ module Deliver
       file_path = [deliver_path, Deliver::Deliverfile::Deliverfile::FILE_NAME].join('/')
       json = generate_deliver_file(app, deliver_path, project_name)
       File.write(file_path, json)
+
+      FileUtils.mkdir_p './screenshots/'
+      ItunesConnect.new.download_existing_screenshots(app)
       
       puts "Successfully created new Deliverfile at '#{file_path}'".green
     end

--- a/lib/deliver/deliverfile/deliverfile_creator.rb
+++ b/lib/deliver/deliverfile/deliverfile_creator.rb
@@ -64,20 +64,25 @@ module Deliver
 
       FileUtils.mkdir_p './screenshots/'
       begin
+        Helper.log.info "Downloading all previously used app screenshots.".green
         ItunesConnect.new.download_existing_screenshots(app)
       rescue
         Helper.log.error "Couldn't download already existing screenshots from iTunesConnect. You have to add them manually!".red
       end
+
+      # Add a README to the screenshots folder
+      FileUtils.mkdir_p File.join(deliver_path, 'screenshots') # just in case the fetching didn't work
+      File.write(File.join(deliver_path, 'screenshots', 'README.txt'), File.read("#{Helper.gem_path('deliver')}/lib/assets/ScreenshotsHelp"))
       
-      puts "Successfully created new Deliverfile at '#{file_path}'".green
+      Helper.log.info "Successfully created new Deliverfile at '#{file_path}'".green
     end
 
     private
       # This method takes care of creating a new 'deliver' folder, containg the app metadata 
       # and screenshots folders
       def self.generate_deliver_file(app, path, project_name)
-        metadata_path = "#{path}/deliver/"
-        FileUtils.mkdir_p metadata_path
+        metadata_path = File.join(path, 'deliver')
+        FileUtils.mkdir_p metadata_path rescue nil # never mind if it's already there
 
         json = create_json_based_on_xml(app, metadata_path)
 
@@ -85,14 +90,11 @@ module Deliver
           json[key].delete(:version_whats_new)
         end
         
-        meta_path = "#{metadata_path}metadata.json"
+        meta_path = File.join(metadata_path, "metadata.json")
         File.write(meta_path, JSON.pretty_generate(json))
         puts "Successfully created new metadata JSON file at '#{meta_path}'".green
 
         gem_path = Helper.gem_path('deliver')
-
-        # Add a README to the screenshots folder
-        File.write("#{metadata_path}screenshots/README.txt", File.read("#{gem_path}/lib/assets/ScreenshotsHelp"))
 
         # Generate the final Deliverfile here
         deliver = File.read("#{gem_path}/lib/assets/DeliverfileDefault")
@@ -118,9 +120,6 @@ module Deliver
           end
 
           json[locale] = current
-
-          # Create an empty folder for the screenshots too
-          FileUtils.mkdir_p "#{path}screenshots/#{locale}/"
         end
 
         return json

--- a/lib/deliver/deliverfile/deliverfile_creator.rb
+++ b/lib/deliver/deliverfile/deliverfile_creator.rb
@@ -63,7 +63,11 @@ module Deliver
       File.write(file_path, json)
 
       FileUtils.mkdir_p './screenshots/'
-      ItunesConnect.new.download_existing_screenshots(app)
+      begin
+        ItunesConnect.new.download_existing_screenshots(app)
+      rescue
+        Helper.log.error "Couldn't download already existing screenshots from iTunesConnect. You have to add them manually!".red
+      end
       
       puts "Successfully created new Deliverfile at '#{file_path}'".green
     end

--- a/lib/deliver/itunes_connect/itunes_connect.rb
+++ b/lib/deliver/itunes_connect/itunes_connect.rb
@@ -7,6 +7,7 @@ require 'deliver/itunes_connect/itunes_connect_new_version'
 require 'deliver/itunes_connect/itunes_connect_app_icon'
 require 'deliver/itunes_connect/itunes_connect_app_rating'
 require 'deliver/itunes_connect/itunes_connect_additional'
+require 'deliver/itunes_connect/itunes_connect_screenshot_fetcher'
 
 module Deliver
   ItunesConnect = FastlaneCore::ItunesConnect

--- a/lib/deliver/itunes_connect/itunes_connect_screenshot_fetcher.rb
+++ b/lib/deliver/itunes_connect/itunes_connect_screenshot_fetcher.rb
@@ -1,0 +1,49 @@
+require 'open-uri'
+
+module FastlaneCore  
+  # For all the information reading (e.g. version number)
+  class ItunesConnect
+    ALL_INFORMATION_URL = "https://itunesconnect.apple.com//WebObjects/iTunesConnect.woa/ra/apps/version/"
+
+    # This method will download all existing app screenshots
+    # @param app (Deliver::App) the app you want this information from
+    # @raise [ItunesConnectGeneralError] General error while executing 
+    #  this action
+    # @raise [ItunesConnectLoginError] Login data is wrong
+    def download_existing_screenshots(app)
+      begin
+        verify_app(app)
+
+        url = ALL_INFORMATION_URL + app.apple_id.to_s
+
+        # Turn off/on the async mode of jQuery
+        evaluate_script("jQuery.ajaxSetup({async:false});")
+        response = evaluate_script("$.get('#{url}').responseText")
+        evaluate_script("jQuery.ajaxSetup({async:true});")
+
+        raise "Could not fetch previously uploaded screenshots" unless response
+
+        data = JSON.parse(response)
+
+        # TODO: instead of .first, it should iterate through all langauges!
+        screenshots = data['data']['details']['value'].first['screenshots']['value']
+
+        screenshots.each do |type, value|
+          value['value'].each do |screenshot|
+            url = screenshot['value']['url']
+            file_name = [screenshot['value']['sortOrder'], type, screenshot['value']['originalFileName']].join("_")
+            Helper.log.info "Downloading screenshot '#{file_name}' of device type: '#{type}'"
+            language = "en-US" # TODO 
+
+            containing_folder = File.join(".", "screenshots", language)
+            FileUtils.mkdir_p containing_folder
+            path = File.join(containing_folder, file_name)
+            File.write(path, open(url).read)
+          end
+        end
+      rescue Exception => ex
+        error_occured(ex)
+      end
+    end
+  end
+end

--- a/spec/deliverfile_creator_spec.rb
+++ b/spec/deliverfile_creator_spec.rb
@@ -62,12 +62,7 @@ describe Deliver do
       correct.gsub!("[[APPLE_ID]]", apple_id.to_s)
       expect(File.read("/tmp/Deliverfile")).to eq(correct)
 
-      expect(File.directory?([deliver_path, "screenshots"].join("/"))).to eq(true)
-      expect(File.directory?([deliver_path, "screenshots", "de-DE"].join("/"))).to eq(true)
-      expect(File.directory?([deliver_path, "screenshots", "en-US"].join("/"))).to eq(true)
-      expect(File.directory?([deliver_path, "screenshots", "en-AU"].join("/"))).to eq(false)
-
-      expect(File.read("/tmp/deliver/screenshots/README.txt")).to eq(File.read("./lib/assets/ScreenshotsHelp"))
+      expect(File.read("/tmp/screenshots/README.txt")).to eq(File.read("./lib/assets/ScreenshotsHelp"))
     end
   end
 end


### PR DESCRIPTION
This pull requests downloads the existing screenshots from iTC and stores it in the screenshots folder

Right now, I haven't found a way to determine the language of the current screenshot list.

The language code is `German`, `Simplified Chinese` and `English`, instead of the usually used language codes (e.g. `en-US`, `de-DE`)

I couldn't find a map from Apple to map the screenshots back into the language code.
