### PR TITLE
Fix bug where automatic_release false did nothing

### DIFF
--- a/lib/deliver/deliver_process.rb
+++ b/lib/deliver/deliver_process.rb
@@ -276,7 +276,7 @@ module Deliver
       itc = ItunesConnect.new
       itc.set_copyright!(@app, @deploy_information[Deliverer::ValKey::COPYRIGHT]) if @deploy_information[Deliverer::ValKey::COPYRIGHT]
       itc.set_app_review_information!(@app, @deploy_information[Deliverer::ValKey::APP_REVIEW_INFORMATION]) if @deploy_information[Deliverer::ValKey::APP_REVIEW_INFORMATION]
-      itc.set_release_after_approval!(@app, @deploy_information[Deliverer::ValKey::AUTOMATIC_RELEASE]) if @deploy_information[Deliverer::ValKey::AUTOMATIC_RELEASE]
+      itc.set_release_after_approval!(@app, @deploy_information[Deliverer::ValKey::AUTOMATIC_RELEASE]) if @deploy_information[Deliverer::ValKey::AUTOMATIC_RELEASE] != nil
 
       # Categories
       primary = @deploy_information[Deliverer::ValKey::PRIMARY_CATEGORY]

--- a/lib/deliver/itunes_connect/itunes_connect_additional.rb
+++ b/lib/deliver/itunes_connect/itunes_connect_additional.rb
@@ -42,8 +42,10 @@ module Deliver
 
       Helper.log.info "Setting automatic release to '#{automatic_release}'".green
 
+      radio_value = automatic_release ? "true" : "false"
+
       # Find the correct radio button
-      first("div[itc-radio='versionInfo.releaseOnApproval.value'][radio-value='#{automatic_release.to_s}'] > * > a").click
+      first("div[itc-radio='versionInfo.releaseOnApproval.value'][radio-value='#{radio_value}'] > * > a").click
 
       (click_on "Save" rescue nil) # if nothing has changed, there is no back button and we don't care
     rescue => ex


### PR DESCRIPTION
I've been using deliver in production for a while and it is awesome! However, we like to manually release new versions, and the `automatic_release` option in the `Deliverfile` hasn't worked.

It looks like `set_release_after_approval!` isn't being called if `automatic_release` is `false`, which is exactly when I would like it to be called! I changed the condition to check against `nil`, which is the value 
of `@deploy_information[Deliverer::ValKey::AUTOMATIC_RELEASE]` if it is _not_ specified in the `Deliverfile`.

I also added in a little truthiness check, just in case anyone accidentally puts something other than `true`/`false`.
