### PR TITLE
Strip URLs before uploading them

### DIFF
--- a/lib/deliver/deliver_process.rb
+++ b/lib/deliver/deliver_process.rb
@@ -189,6 +189,7 @@ module Deliver
           content = File.read(File.join(language_folder, "#{key}.txt")) rescue nil
           next unless content
           content = content.split("\n") if key == 'keywords'
+          content = content.strip if key == 'privacy_url' || key == 'software_url' || key == 'support_url'
           @deploy_information[value] ||= {}
           @deploy_information[value][language] ||= content
 


### PR DESCRIPTION
I use atom for text editing and it adds an extra new line at the end of files by default when saving. This causes the `privacy_url`, `software_url` and `support_url` to fail to upload to iTunes Connect since the url is invalid. To fix this issue I striped the URLs of newlines and spaces since they should not be there anyways.
