### PR TITLE
Fixes incorrect language default message

### DIFF
--- a/lib/deliver/deliverfile/dsl.rb
+++ b/lib/deliver/deliverfile/dsl.rb
@@ -6,7 +6,7 @@ module Deliver
     class Deliverfile
       module DSL
         MISSING_VALUE_ERROR_MESSAGE = "You have to pass either a value or a block to the given method."
-        SPECIFY_LANGUAGE_FOR_VALUE = "You have to specify the language of the given value. Either set a default language using 'default_language \"en\"' on the top of the file or pass a hash containing the language codes"
+        SPECIFY_LANGUAGE_FOR_VALUE = "You have to specify the language of the given value. Either set a default language using 'default_language \"en-US\"' on the top of the file or pass a hash containing the language codes"
 
         MISSING_APP_IDENTIFIER_MESSAGE = "You have to pass a valid app identifier using the Deliver file. (e.g. 'app_identifier \"net.sunapps.app\"')"
         MISSING_VERSION_NUMBER_MESSAGE = "You have to pass a valid version number using the Deliver file. (e.g. 'version \"1.0\"')"


### PR DESCRIPTION
Previously I didn't specify a language in my Deliverfile. So when I ran `fastlane deploy`, it through an exception with the `SPECIFY_LANGUAGE_FOR_VALUE` message (as expected). So I added `default_language "en"` to my Deliverfile. Fastlane then ran correctly until iTunes Transporter successfully finished its job. After that, it attempted to set the language and threw the following exception:

``` ruby
[09:10:57]: Language 'en' is invalid. It must be in ["da-DK", "de-DE", "el-GR", "en-AU", "en-CA", "en-GB", "en-US", "es-ES", "es-MX", "fi-FI", "fr-CA", "fr-FR", "id-ID", "it-IT", "ja-JP", "ko-KR", "ms-MY", "nl-NL", "no-NO", "pt-BR", "pt-PT", "ru-RU", "sv-SE", "th-TH", "tr-TR", "vi-VI", "cmn-Hans", "cmn-Hant"].
[09:10:58]: fastlane finished with errors

```

This just updates the error message to a valid language code. Let me know if this PR needs to be submitted elsewhere (there are a lot of branches!)
