### PR TITLE
Removed the flawed check of the public iTunes API for the app version.

### DIFF
--- a/lib/deliver/deliver_process.rb
+++ b/lib/deliver/deliver_process.rb
@@ -55,9 +55,9 @@ module Deliver
 
     def upload_metadata
       if ready_for_sale?
-        raise "Cannot update metadata of apps 'Ready for Sale'. You can dupe: http://www.openradar.appspot.com/18263306".red 
+        raise "Cannot update metadata of apps 'Ready for Sale'. You can dupe: http://www.openradar.appspot.com/18263306".red
       end
-      
+
       load_metadata_from_config_json_folder # the json file generated from the quick start # deprecated
       load_metadata_folder # this is the new way of defining app metadata
       set_app_metadata
@@ -110,8 +110,7 @@ module Deliver
 
       @app_version ||= @deploy_information[Deliverer::ValKey::APP_VERSION]
       @app_version ||= (@ipa.fetch_app_version rescue nil) # since ipa might be nil
-      @app_version ||= (FastlaneCore::ItunesSearchApi.fetch_by_identifier(app_identifier)['version'] rescue nil)
-      @app_version ||= (app.get_live_version rescue nil)
+      @app_version ||= (app.get_live_version rescue nil) # pull the latest version from iTunes Connect
     end
 
     #####################################################
@@ -178,11 +177,11 @@ module Deliver
 
         Deliverfile::Deliverfile::DSL.validate_ipa!(used_ipa_file)
       end
-      
+
       if (used_ipa_file || '').length == 0 and is_beta_build?
         # Beta Release but no ipa given
         used_ipa_file = Dir["*.ipa"].first
-        
+
         unless used_ipa_file
           raise "Could not find an ipa file for 'beta' mode. Provide one using `beta_ipa do ... end` in your Deliverfile.".red
         end
@@ -399,7 +398,7 @@ module Deliver
         # Custom error handling, we just call this one
         @deploy_information[:blocks][:error].call(hash_for_callback(ex))
       end
-      
+
       # Re-Raise the exception
       raise ex
     end

--- a/spec/example_deliver_files_spec.rb
+++ b/spec/example_deliver_files_spec.rb
@@ -44,13 +44,6 @@ describe Deliver do
             Deliver::ItunesTransporter.set_mock_file("spec/responses/transporter/download_valid_apple_id.txt")
           end
 
-          it "automatically fetches the version number from the iTunes Connect API" do
-            Deliver::ItunesTransporter.set_mock_file("spec/responses/transporter/upload_valid.txt")
-
-            meta = Deliver::Deliverer.new("./spec/fixtures/Deliverfiles/DeliverfileMissingAppVersion")
-            expect(meta.deliver_process.app.metadata.fetch_value("//x:version").first['string']).to eq("1.0")
-          end
-
           it "successfully loads the Deliverfile if it's valid" do
             Deliver::ItunesTransporter.set_mock_file("spec/responses/transporter/upload_valid.txt")
 
@@ -87,7 +80,7 @@ describe Deliver do
 
             ipa_path = "./spec/fixtures/ipas/Example1.ipa"
             ENV["IPA_OUTPUT_PATH"] = ipa_path
-            
+
             meta = Deliver::Deliverer.new("./spec/fixtures/Deliverfiles/DeliverfileIpaFromEnv")
 
             expect(ENV["DELIVER_IPA_PATH"]).to eq(ipa_path) # use this ipa
@@ -97,7 +90,7 @@ describe Deliver do
 
           it "Raises an exception when iTunes Transporter results in an error" do
             Deliver::ItunesTransporter.set_mock_file("spec/responses/transporter/upload_ipa_error.txt")
-            
+
             expect {
               Deliver::Deliverer.new("./spec/fixtures/Deliverfiles/DeliverfileCallbacks")
             }.to raise_exception("Return status of iTunes Transporter was 1: ERROR ITMS-9000: \"Redundant Binary Upload. There already exists a binary upload with build '247' for version '1.13.0'\"".red)
@@ -236,9 +229,9 @@ describe Deliver do
               expect(File.exists?@tests_path).to eq(false)
               Deliver::ItunesTransporter.clear_mock_files # we don't even download the app metadata
               Deliver::ItunesTransporter.set_mock_file("spec/responses/transporter/upload_valid.txt") # the ipa file
-              deliv = Deliver::Deliverer.new("./spec/fixtures/Deliverfiles/DeliverfileCallbacks", 
-                                force: true, 
-                                is_beta_ipa: true, 
+              deliv = Deliver::Deliverer.new("./spec/fixtures/Deliverfiles/DeliverfileCallbacks",
+                                force: true,
+                                is_beta_ipa: true,
                                 skip_deploy: true)
               expect(File.exists?@tests_path).to eq(true)
               expect(File.exists?@success_path).to eq(true)


### PR DESCRIPTION
Previously the `@app_version` would be invalid if no IPA was provided and there was an unreleased version in iTunes Connect. 

This was because it's trying to search the public iTunes API for the latest version, for example `1.3`. If I have version `2.0` in iTunes Connect, `deliver_process` won't get to the iTunes Connect check, because it's already grabbed `1.3` from the public API, which is incorrect.

This simply removes the step that checks the public API, because there is no way to guarantee that it is up to date.
