### PR TITLE
Fix 'What to Test' only updated for 1st language on beta upload

### DIFF
--- a/lib/deliver/itunes_connect/itunes_connect_submission.rb
+++ b/lib/deliver/itunes_connect/itunes_connect_submission.rb
@@ -73,9 +73,9 @@ module Deliver
         Helper.log.info "DELIVER_BETA_FEEDBACK_EMAIL: '#{ENV['DELIVER_BETA_FEEDBACK_EMAIL']}'"
 
         build_info['details'].each_with_index do |hash, index|
-          build_info['details'][0]['whatsNew']['value'] = ENV["DELIVER_WHAT_TO_TEST"]
-          build_info['details'][index]['description']['value'] = ENV["DELIVER_BETA_DESCRIPTION"]
-          build_info['details'][index]['feedbackEmail']['value'] = ENV["DELIVER_BETA_FEEDBACK_EMAIL"]
+          build_info['details'][index]['whatsNew']['value'] = ENV["DELIVER_WHAT_TO_TEST"]
+          build_info['details'][index]['description']['value'] ||= ENV["DELIVER_BETA_DESCRIPTION"]
+          build_info['details'][index]['feedbackEmail']['value'] ||= ENV["DELIVER_BETA_FEEDBACK_EMAIL"]
         end
         
         h = Excon.post(build_url, body: build_info.to_json, headers: { "Cookie" => cookie_string } )


### PR DESCRIPTION
It seems that the "What to Test" metadata field is only being updated for the first entry in the json while the others are updated for all languages. I'm thinking it was supposed to apply to all of them, so I tested this and it worked as I expected. Also, I'd like to have the description and email only updated if new information is provided, this fits with the behavior of the site when not using deliver. Any comments or suggestions are welcome.
