### PR TITLE
Fix bug where DELIVER_VERSION is an empty string

### DIFF
--- a/lib/deliver/deliver_process.rb
+++ b/lib/deliver/deliver_process.rb
@@ -109,7 +109,7 @@ module Deliver
       @app_identifier ||= (@ipa.fetch_app_identifier rescue nil) # since ipa might be nil
 
       @app_version ||= @deploy_information[Deliverer::ValKey::APP_VERSION]
-      @app_version ||= ENV["DELIVER_VERSION"]
+      @app_version ||= ENV["DELIVER_VERSION"] if not ENV["DELIVER_VERSION"].nil? and not ENV["DELIVER_VERSION"].empty? # since DELIVER_VERSION can be ''
       @app_version ||= (@ipa.fetch_app_version rescue nil) # since ipa might be nil
       @app_version ||= (app.get_live_version rescue nil) # pull the latest version from iTunes Connect
     end


### PR DESCRIPTION
When DELIVER_VERSION is an empty string, this is propagated and used throughout the delivery process. This fix will make the code more robust against such cases.
