### PR TITLE
Add support to init with live_version i/o latest_version

### DIFF
--- a/MigrationGuide.md
+++ b/MigrationGuide.md
@@ -36,7 +36,7 @@ Removed     | Use instead              | Note
 
 From     | To              | Note
 ---------|-----------------|------------------------------------------------------------
-`title`  | `name` | requires a hash: `name({ "en-US" => "App name" })`
+`title`  | `name` | requires `name({ "en-US" => "App name" })`
 `changelog` | `release_notes`
 `keywords` |   | requires a simple string instead of arrays
 `ratings_config_path` | `app_rating_config_path` | [New Format](https://github.com/KrauseFx/deliver/blob/master/Deliverfile.md#app_rating_config_path)

--- a/MigrationGuide.md
+++ b/MigrationGuide.md
@@ -36,7 +36,7 @@ Removed     | Use instead              | Note
 
 From     | To              | Note
 ---------|-----------------|------------------------------------------------------------
-`title`  | `name` | requires a hash: `name ({ "en-US" => "App name" })`
+`title`  | `name` | requires a hash: `name({ "en-US" => "App name" })`
 `changelog` | `release_notes`
 `keywords` |   | requires a simple string instead of arrays
 `ratings_config_path` | `app_rating_config_path` | [New Format](https://github.com/KrauseFx/deliver/blob/master/Deliverfile.md#app_rating_config_path)
@@ -69,9 +69,7 @@ App Categories | [Reference.md](https://github.com/KrauseFx/deliver/blob/master/
 - Removed the `deliver beta` and `testflight` commands, as there is now a dedicated tool called [pilot](https://github.com/fastlane/pilot)
 - All parameters are now in the config system, which means you can pass values using the `Deliverfile`, from within your `Fastfile` or as command line parameter
 <img width="500" alt="screenshot 2015-09-26 21 57 15" src="https://cloud.githubusercontent.com/assets/869950/10121297/c6ea1c7a-6499-11e5-8d2b-301f86faacf0.png">
-- The preview doesn't currently show changes in blue
+- The preview doesn't highlight changes with blue any more
 - Screenshot are uploaded every time. This is on the [next-tasks list](https://github.com/KrauseFx/deliver/issues/353)
-- Apple watch screenshots are not currently supported. This is on the [next-tasks list](https://github.com/KrauseFx/deliver/issues/353)
-
 
 If you run into any issues with the new version of `deliver` please submit an issue on GitHub.

--- a/deliver.gemspec
+++ b/deliver.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   # fastlane dependencies
   spec.add_dependency 'fastlane_core', '>= 0.18.2', '< 1.0.0' # all shared code and dependencies
   spec.add_dependency 'credentials_manager', '>= 0.8.1'
-  spec.add_dependency 'spaceship', '>= 0.10.1', '<= 1.0.0' # Communication with iTunes Connect
+  spec.add_dependency 'spaceship', '>= 0.10.2', '<= 1.0.0' # Communication with iTunes Connect
 
   # third party dependencies
   spec.add_dependency 'nokogiri', '~> 1.6.5' # parsing and updating XML files

--- a/lib/deliver/app_screenshot.rb
+++ b/lib/deliver/app_screenshot.rb
@@ -52,7 +52,7 @@ module Deliver
         ScreenSize::IOS_55 => "iphone6Plus",
         ScreenSize::IOS_IPAD => "ipad",
         ScreenSize::MAC => "mac",
-        ScreenSize::IOS_APPLE_WATCH => "Watch"
+        ScreenSize::IOS_APPLE_WATCH => "watch"
       }
       return matching[self.screen_size]
     end

--- a/lib/deliver/options.rb
+++ b/lib/deliver/options.rb
@@ -43,6 +43,11 @@ module Deliver
                                      short_option: '-z',
                                      description: "The version that should be edited or created",
                                      optional: true),
+        FastlaneCore::ConfigItem.new(key: :init_app_version,
+                                     short_option: "-k",
+                                     description: "The version that should be initialized with. Currently only [live_version, latest_version] are supported default : latest_version", # @todo : Would be great to init with an App Store version number like "3.0"
+                                     optional: true,
+                                     is_string: true),
         FastlaneCore::ConfigItem.new(key: :skip_metadata,
                                      description: "Only upload the build - no metadata",
                                      is_string: false,

--- a/lib/deliver/setup.rb
+++ b/lib/deliver/setup.rb
@@ -28,7 +28,13 @@ module Deliver
     # This method takes care of creating a new 'deliver' folder, containg the app metadata
     # and screenshots folders
     def generate_deliver_file(deliver_path, options)
-      v = options[:app].latest_version
+      if options[:init_app_version] == "live_version"
+        print "Init with live_version"
+        v = options[:app].live_version
+      else
+        v = options[:app].latest_version
+      end
+
       generate_metadata_files(v, deliver_path)
 
       # Generate the final Deliverfile here

--- a/lib/deliver/upload_screenshots.rb
+++ b/lib/deliver/upload_screenshots.rb
@@ -49,13 +49,16 @@ module Deliver
       Dir.glob(File.join(options[:screenshots_path], "*"), File::FNM_CASEFOLD).sort.each do |lng_folder|
         language = File.basename(lng_folder)
 
-        files = Dir.glob(File.join(lng_folder, '*.{png,PNG,jpg,JPG}'))
+        files = Dir.glob(File.join(lng_folder, '*.{png,jpg}'))
         next if files.count == 0
 
-        prefer_framed = Dir.glob(File.join(lng_folder, '*_framed.{png,PNG,jpg,JPG}')).count > 0
+        prefer_framed = Dir.glob(File.join(lng_folder, '*_framed.{png,jpg}')).count > 0
 
         files.each do |path|
-          next if prefer_framed && !path.include?("_framed.{png,PNG,jpg,JPG}")
+          if prefer_framed && !path.include?("_framed.{png,PNG,jpg,JPG}") && !path.downcase.include?("watch")
+            next
+          end
+
           screenshots << AppScreenshot.new(path, language)
         end
       end

--- a/lib/deliver/upload_screenshots.rb
+++ b/lib/deliver/upload_screenshots.rb
@@ -49,13 +49,13 @@ module Deliver
       Dir.glob(File.join(options[:screenshots_path], "*"), File::FNM_CASEFOLD).sort.each do |lng_folder|
         language = File.basename(lng_folder)
 
-        files = Dir.glob(File.join(lng_folder, '*.png'))
+        files = Dir.glob(File.join(lng_folder, '*.{png,PNG,jpg,JPG}'))
         next if files.count == 0
 
-        prefer_framed = Dir.glob(File.join(lng_folder, '*_framed.png')).count > 0
+        prefer_framed = Dir.glob(File.join(lng_folder, '*_framed.{png,PNG,jpg,JPG}')).count > 0
 
         files.each do |path|
-          next if prefer_framed && !path.include?("_framed.png")
+          next if prefer_framed && !path.include?("_framed.{png,PNG,jpg,JPG}")
           screenshots << AppScreenshot.new(path, language)
         end
       end

--- a/lib/deliver/upload_screenshots.rb
+++ b/lib/deliver/upload_screenshots.rb
@@ -49,16 +49,14 @@ module Deliver
       Dir.glob(File.join(options[:screenshots_path], "*"), File::FNM_CASEFOLD).sort.each do |lng_folder|
         language = File.basename(lng_folder)
 
-        files = Dir.glob(File.join(lng_folder, '*.{png,jpg}'))
+
+        files = Dir.glob(File.join(lng_folder, '*.{png,jpg,jpeg}'))
         next if files.count == 0
 
-        prefer_framed = Dir.glob(File.join(lng_folder, '*_framed.{png,jpg}')).count > 0
+        prefer_framed = Dir.glob(File.join(lng_folder, '*_framed.{png,jpg,jpeg}')).count > 0
 
         files.each do |path|
-          if prefer_framed && !path.include?("_framed.{png,PNG,jpg,JPG}") && !path.downcase.include?("watch")
-            next
-          end
-
+          next if prefer_framed && !path.include?("_framed.{png,jpg,jpeg}")
           screenshots << AppScreenshot.new(path, language)
         end
       end

--- a/lib/deliver/upload_screenshots.rb
+++ b/lib/deliver/upload_screenshots.rb
@@ -49,13 +49,13 @@ module Deliver
       Dir.glob(File.join(options[:screenshots_path], "*"), File::FNM_CASEFOLD).sort.each do |lng_folder|
         language = File.basename(lng_folder)
 
-        files = Dir.glob(File.join(lng_folder, '*.png'))
+        files = Dir.glob(File.join(lng_folder, '*.{png,jpg,jpeg}'))
         next if files.count == 0
 
-        prefer_framed = Dir.glob(File.join(lng_folder, '*_framed.png')).count > 0
+        prefer_framed = Dir.glob(File.join(lng_folder, '*_framed.{png,jpg,jpeg}')).count > 0
 
         files.each do |path|
-          next if prefer_framed && !path.include?("_framed.png")
+          next if prefer_framed && !path.include?("_framed.{png,jpg,jpeg}")
           screenshots << AppScreenshot.new(path, language)
         end
       end

--- a/lib/deliver/version.rb
+++ b/lib/deliver/version.rb
@@ -1,4 +1,4 @@
 module Deliver
-  VERSION = "1.1.1"
+  VERSION = "1.1.2"
   DESCRIPTION = 'Upload screenshots, metadata and your app to the App Store using a single command'
 end

--- a/lib/deliver/version.rb
+++ b/lib/deliver/version.rb
@@ -1,4 +1,4 @@
 module Deliver
-  VERSION = "1.1.0"
+  VERSION = "1.1.1"
   DESCRIPTION = 'Upload screenshots, metadata and your app to the App Store using a single command'
 end


### PR DESCRIPTION
I made a quick fix for myself that could be useful for others
Regarding #366

Would be great to init with an App Store version number like "3.0"
But I didn't have enough time to look into Spaceship application version retrieving.
