### PR TITLE
Fixed build.processing not being refreshed and never completes

### DIFF
--- a/lib/deliver/submit_for_review.rb
+++ b/lib/deliver/submit_for_review.rb
@@ -48,6 +48,11 @@ module Deliver
       end
 
       loop do
+        v.candidate_builds.each do |b|
+          if b.upload_date == build.upload_date
+            build = b
+          end
+        end
         break if build.processing == false
 
         Helper.log.info "Waiting iTunes Connect processing... this might take a while..."

--- a/lib/deliver/submit_for_review.rb
+++ b/lib/deliver/submit_for_review.rb
@@ -70,7 +70,7 @@ module Deliver
       end
 
       unless build
-        Helper.log.fatal v.candidate_builds
+        Helper.log.fatal app.latest_version.candidate_builds
         raise "Could not find build".red
       end
 


### PR DESCRIPTION
Hey @KrauseFx 

I discovered a bug in the pull request you merged from me. My builds never wait for processing because I submit a batch of 150 before selecting the build so I missed it in my testing. Basically it seems that calling build.processing doesn't re-retrieve the build object from ITC therefore processing is not refreshed, so it will never change to true. The fix basically re-retrieves and finds the same build based on the upload_date and then checks the status from there
