### PR TITLE
[Loader] Add unified way to load localised folders from FS.

### DIFF
--- a/deliver.gemspec
+++ b/deliver.gemspec
@@ -40,4 +40,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'coveralls'
   spec.add_development_dependency 'fastlane'
   spec.add_development_dependency 'rubocop', '~> 0.34'
+  spec.add_development_dependency 'fakefs'
 end

--- a/lib/deliver.rb
+++ b/lib/deliver.rb
@@ -11,6 +11,7 @@ require 'deliver/upload_assets'
 require 'deliver/submit_for_review'
 require 'deliver/app_screenshot'
 require 'deliver/html_generator'
+require 'deliver/loader'
 
 require 'spaceship'
 require 'fastlane_core'

--- a/lib/deliver/loader.rb
+++ b/lib/deliver/loader.rb
@@ -1,0 +1,13 @@
+require 'fastlane_core/languages'
+
+module Deliver
+  module Loader
+    ALL_LANGUAGES = FastlaneCore::Languages::ALL_LANGUAGES.map(&:downcase).freeze
+
+    def self.language_folders(root)
+      Dir.glob(File.join(root, '*')).select do |path|
+        File.directory?(path) && ALL_LANGUAGES.include?(File.basename(path).downcase)
+      end.sort
+    end
+  end
+end

--- a/lib/deliver/upload_metadata.rb
+++ b/lib/deliver/upload_metadata.rb
@@ -95,11 +95,8 @@ module Deliver
       return if options[:skip_metadata]
 
       # Load localised data
-      Dir.glob(File.join(options[:metadata_path], "*")).each do |lng_folder|
-        next unless File.directory?(lng_folder) # We don't want to read txt as they are non localised
-
+      Loader.language_folders(options[:metadata_path]).each do |lng_folder|
         language = File.basename(lng_folder)
-
         (LOCALISED_VERSION_VALUES + LOCALISED_APP_VALUES).each do |key|
           path = File.join(lng_folder, "#{key}.txt")
           next unless File.exist?(path)

--- a/lib/deliver/upload_screenshots.rb
+++ b/lib/deliver/upload_screenshots.rb
@@ -51,14 +51,13 @@ module Deliver
 
       screenshots = []
       extensions = '{png,jpg,jpeg}'
-      Dir.glob(File.join(options[:screenshots_path], "*"), File::FNM_CASEFOLD).sort.each do |lng_folder|
-        language = File.basename(lng_folder)
-
+      Loader.language_folders(options[:screenshots_path]).each do |lng_folder|
         files = Dir.glob(File.join(lng_folder, "*.#{extensions}"))
         next if files.count == 0
 
         prefer_framed = Dir.glob(File.join(lng_folder, '*_framed.#{extensions}')).count > 0
 
+        language = File.basename(lng_folder)
         files.each do |path|
           if prefer_framed && !path.downcase.include?("_framed.#{extensions}") && !path.downcase.include?("watch")
             next

--- a/spec/loader_spec.rb
+++ b/spec/loader_spec.rb
@@ -1,0 +1,35 @@
+require 'deliver/loader'
+require 'fakefs/spec_helpers'
+
+describe Deliver::Loader do
+  include FakeFS::SpecHelpers
+
+  before do
+    @languages = FastlaneCore::Languages::ALL_LANGUAGES
+
+    @root = '/some/root'
+    FileUtils.mkdir_p(@root)
+
+    # Add a file with a lang code
+    File.open(File.join(@root, @languages.first), 'w') { |f| f << 'touch' }
+    # Create dirs for all the other codes
+    @languages[1..-1].each.with_index do |lang, index|
+      FileUtils.mkdir(File.join(@root, (index.even? ? lang : lang.downcase)))
+    end
+    # Create an unrelated dir
+    FileUtils.mkdir(File.join(@root, 'unrelated-dir'))
+
+    @folders = Deliver::Loader.language_folders(@root)
+    expect(@folders.size).not_to eq(0)
+  end
+
+  it 'only returns directories in the specified directory' do
+    expect(@folders.all? { |f| File.directory?(f) }).to eq(true)
+  end
+
+  it 'only returns directories that match available language codes, regardless of case' do
+    expected_languages = @languages[1..-1].map(&:downcase).sort
+    actual_languages = @folders.map { |f| File.basename(f) }.map(&:downcase).sort
+    expect(actual_languages).to eq(expected_languages)
+  end
+end


### PR DESCRIPTION
Only returns those languages that are known to Fastlane.

This is useful when you decide to have a custom FS layout, such as we have in the Artsy app where we have `common` directories. ([Here](https://github.com/artsy/eigen/tree/eloy-start-fastlane-integration/fastlane/metadata/common) and [here](https://github.com/artsy/eigen/tree/eloy-start-fastlane-integration/fastlane/screenshots/common).)
