### PR TITLE
Update development dependency

### DIFF
--- a/deliver.gemspec
+++ b/deliver.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'spaceship', '>= 0.14.0', '<= 1.0.0' # Communication with iTunes Connect
 
   # third party dependencies
-  spec.add_dependency 'fastimage', '~> 1.41.0' # fetch the image sizes from the screenshots
+  spec.add_dependency 'fastimage', '~> 1.6.3' # fetch the image sizes from the screenshots
   spec.add_dependency 'plist', '~> 3.1.0' # for reading the Info.plist of the ipa file
 
   # Development only

--- a/deliver.gemspec
+++ b/deliver.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'spaceship', '>= 0.14.0', '<= 1.0.0' # Communication with iTunes Connect
 
   # third party dependencies
-  spec.add_dependency 'fastimage', '~> 1.6.3' # fetch the image sizes from the screenshots
+  spec.add_dependency 'fastimage', '~> 1.6' # fetch the image sizes from the screenshots
   spec.add_dependency 'plist', '~> 3.1.0' # for reading the Info.plist of the ipa file
 
   # Development only


### PR DESCRIPTION
This PR reverts the change to depend on `fastimage 1.41.0` which doesn't exist (maybe it was yanked?) and locks on `fastimage ~> 1.6` which allows us to use 1.8.0 but does not create version conflicts with [`spaceship`](https://github.com/fastlane/spaceship/blob/master/spaceship.gemspec#L33) and [`snapshot`](https://github.com/fastlane/snapshot/blob/master/snapshot.gemspec#L24)
