### PR TITLE
Add new shopping category to reference

### DIFF
--- a/Reference.md
+++ b/Reference.md
@@ -20,6 +20,7 @@ You can always prefix the category using `MZGenre.` (e.g. `MZGenre.Book`). `deli
 - `Photography`
 - `Productivity`
 - `Reference`
+- `Shopping`
 - `SocialNetworking`
 - `Sports`
 - `Travel`


### PR DESCRIPTION
Apple now support a new category just for `Shopping` apps, this just adds reference to them in the reference guide.
