### PR TITLE
Exit with non-zero status if binary upload failed

### DIFF
--- a/lib/deliver/runner.rb
+++ b/lib/deliver/runner.rb
@@ -22,7 +22,9 @@ module Deliver
 
       has_binary = (options[:ipa] || options[:pkg])
       if !options[:skip_binary_upload] && !options[:build_number] && has_binary
-        upload_binary
+        unless upload_binary
+          UI.user_error!("Upload binary failed")
+        end
       end
 
       UI.success("Finished the upload to iTunes Connect")


### PR DESCRIPTION
Currently, fastlane only prints to the log file if the binary upload failed, hiding this information from callers unless they parse the text output.

An ugly side effect of the current code would be to submit an app for review with the old binary.
