### PR TITLE
Initial support for Mac apps submission

### DIFF
--- a/Deliverfile.md
+++ b/Deliverfile.md
@@ -24,6 +24,12 @@ ipa "App.ipa"
 
 if you use [fastlane](https://fastlane.tools) the ipa file will automatically be detected.
 
+##### pkg
+A path to a signed pkg file, which will be uploaded. Submission logic of ipa applies to pkg files.
+```ruby
+pkg "MacApp.pkg"
+```
+
 ##### app_version
 
 Optional, as it is usually automatically detected. Specify the version that should be created / edited on iTunes Connect:

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ deliver
 
 ###### Upload screenshots, metadata and your app to the App Store using a single command
 
-`deliver` can upload ipa files, app screenshots and more to iTunes Connect from the command line.
+`deliver` can upload ipa or pkg files, app screenshots and more to iTunes Connect from the command line.
 
 Get in contact with the developer on Twitter: [@FastlaneTools](https://twitter.com/FastlaneTools)
 
@@ -56,7 +56,7 @@ Get in contact with the developer on Twitter: [@FastlaneTools](https://twitter.c
 
 # Features
 - Upload hundreds of localised screenshots completely automatically
-- Upload a new ipa file to iTunes Connect without Xcode from any Mac
+- Upload a new ipa/pkg file to iTunes Connect without Xcode from any Mac
 - Maintain your app metadata locally and push changes back to iTunes Connect
 - Easily implement a real Continuous Deployment process using [fastlane](https://fastlane.tools)
 - Store the configuration in git to easily deploy from **any** Mac, including your Continuous Integration server
@@ -110,7 +110,13 @@ Provide the path to an `ipa` file to upload and submit your app for review:
 deliver --ipa "App.ipa" --submit_for_review
 ```
 
-If you use [fastlane](https://fastlane.tools) you don't have to manually specify the path to your `ipa` file. 
+or you can specify path to `pkg` file for Mac OS X apps:
+
+```
+deliver --pkg "MacApp.pkg"
+```
+
+If you use [fastlane](https://fastlane.tools) you don't have to manually specify the path to your `ipa`/`pkg` file.
 
 This is just a small sub-set of what you can do with `deliver`, check out the full documentation in [Deliverfile.md](https://github.com/fastlane/deliver/blob/master/Deliverfile.md)
 

--- a/lib/deliver/commands_generator.rb
+++ b/lib/deliver/commands_generator.rb
@@ -36,7 +36,7 @@ module Deliver
         c.action do |args, options|
           options = FastlaneCore::Configuration.create(Deliver::Options.available_options, options.__hash__)
           loaded = options.load_configuration_file("Deliverfile")
-          loaded = true if options[:description] || options[:ipa] # do we have *anything* here?
+          loaded = true if options[:description] || options[:ipa] || options[:pkg] # do we have *anything* here?
           unless loaded
             if agree("No deliver configuration found in the current directory. Do you want to setup deliver? (y/n)".yellow, true)
               require 'deliver/setup'

--- a/lib/deliver/detect_values.rb
+++ b/lib/deliver/detect_values.rb
@@ -12,9 +12,11 @@ module Deliver
 
       if options[:ipa]
         identifier = FastlaneCore::IpaFileAnalyser.fetch_app_identifier(options[:ipa])
-        options[:app_identifier] = identifier if identifier.to_s.length > 0
+      elsif options[:pkg]
+        identifier = FastlaneCore::PkgFileAnalyser.fetch_app_identifier(options[:pkg])
       end
 
+      options[:app_identifier] = identifier if identifier.to_s.length > 0
       options[:app_identifier] ||= ask("The Bundle Identifier of your App: ")
     end
 
@@ -41,6 +43,8 @@ module Deliver
     def find_version(options)
       if options[:ipa]
         options[:app_version] ||= FastlaneCore::IpaFileAnalyser.fetch_app_version(options[:ipa])
+      elsif options[:pkg]
+        options[:app_version] ||= FastlaneCore::PkgFileAnalyser.fetch_app_version(options[:pkg])
       end
     end
   end

--- a/lib/deliver/options.rb
+++ b/lib/deliver/options.rb
@@ -33,6 +33,24 @@ module Deliver
                                      verify_block: proc do |value|
                                        raise "Could not find ipa file at path '#{value}'".red unless File.exist?(value)
                                        raise "'#{value}' doesn't seem to be an ipa file".red unless value.end_with?(".ipa")
+                                     end,
+                                     conflicting_options: [:pkg],
+                                     conflict_block: proc do |value|
+                                       raise "You can't use 'ipa' and '#{value.key}' options in one run.".red
+                                     end),
+        FastlaneCore::ConfigItem.new(key: :pkg,
+                                     short_option: "-c",
+                                     optional: true,
+                                     env_name: "DELIVER_PKG_PATH",
+                                     description: "Path to your pkg file",
+                                     default_value: Dir["*.pkg"].first,
+                                     verify_block: proc do |value|
+                                       raise "Could not find pkg file at path '#{value}'".red unless File.exist?(value)
+                                       raise "'#{value}' doesn't seem to be a pkg file".red unless value.end_with?(".pkg")
+                                     end,
+                                     conflicting_options: [:ipa],
+                                     conflict_block: proc do |value|
+                                       raise "You can't use 'pkg' and '#{value.key}' options in one run.".red
                                      end),
         FastlaneCore::ConfigItem.new(key: :metadata_path,
                                      short_option: '-m',

--- a/lib/deliver/runner.rb
+++ b/lib/deliver/runner.rb
@@ -19,7 +19,7 @@ module Deliver
     def run
       verify_version if options[:app_version].to_s.length > 0
       upload_metadata
-      upload_binary if options[:ipa]
+      upload_binary if options[:ipa] || options[:pkg]
 
       Helper.log.info "Finished the upload to iTunes Connect".green
 
@@ -59,11 +59,19 @@ module Deliver
     # Upload the binary to iTunes Connect
     def upload_binary
       Helper.log.info "Uploading binary to iTunes Connect"
-      package_path = FastlaneCore::IpaUploadPackageBuilder.new.generate(
-        app_id: options[:app].apple_id,
-        ipa_path: options[:ipa],
-        package_path: "/tmp"
-      )
+      if options[:ipa]
+        package_path = FastlaneCore::IpaUploadPackageBuilder.new.generate(
+          app_id: options[:app].apple_id,
+          ipa_path: options[:ipa],
+          package_path: "/tmp"
+        )
+      elsif options[:pkg]
+        package_path = FastlaneCore::PkgUploadPackageBuilder.new.generate(
+          app_id: options[:app].apple_id,
+          pkg_path: options[:pkg],
+          package_path: "/tmp"
+        )
+      end
 
       transporter = FastlaneCore::ItunesTransporter.new(options[:username])
       transporter.upload(options[:app].apple_id, package_path)


### PR DESCRIPTION
_WARNING: this PR requires conflicting options functionality from [another pull request](https://github.com/fastlane/fastlane_core/pull/82) to `fastlane_core`_

This PR adds initial support for OS X apps submission. With this patch users of `deliver` should be able to upload signed `pkg` files using `--pkg` key or it's short version `-c`(You may be wondering why `c`? Well it's mostly because `p`, `k` and `g` are occupied already. If you have better idea of naming please let me know).

 Feedback and comments are greatly appreciated!
