### PR TITLE
Fix case-sensitive discovery of screenshots on Ruby < 2.2

### DIFF
--- a/lib/deliver/upload_screenshots.rb
+++ b/lib/deliver/upload_screenshots.rb
@@ -70,10 +70,10 @@ module Deliver
           next
         end
 
-        files = Dir.glob(File.join(lng_folder, "*.#{extensions}"))
+        files = Dir.glob(File.join(lng_folder, "*.#{extensions}"), File::FNM_CASEFOLD)
         next if files.count == 0
 
-        prefer_framed = Dir.glob(File.join(lng_folder, "*_framed.#{extensions}")).count > 0
+        prefer_framed = Dir.glob(File.join(lng_folder, "*_framed.#{extensions}"), File::FNM_CASEFOLD).count > 0
 
         language = File.basename(lng_folder)
         files.each do |file_path|


### PR DESCRIPTION
Addresses #531

On Ruby 2.1.x, `Dir.glob()` acts case-sensitively, but it doesn't on Ruby 2.2.3. This passes a flag to `Dir.glob()` to make it always match case insensitively when we are searching for *.{png,jpg,jpeg} etc.
