### PR TITLE
Support a 'default' locale folder for fall-back values

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,51 @@ Before actually uploading anything to iTunes, ```deliver``` will generate a HTML
 no, en-US, en-CA, fi, ru, zh-Hans, nl-NL, zh-Hant, en-AU, id, de-DE, sv, ko, ms, pt-BR, el, es-ES, it, fr-CA, es-MX, pt-PT, vi, th, ja, fr-FR, da, tr, en-GB
 ```
 
+## Default values
+
+Deliver has a special `default` language code which allows you to provide values that are not localised, and which will be used as defaults when you don’t provide a specific localised value.
+
+You can use this either in json within your deliverfile, or as a folder in your metadata file.
+
+Imagine that you have localised data for the following language codes:  ```en-US, de-DE, el, it```
+
+You can set the following in your deliverfile
+
+```
+release_notes({
+  'default' => "Shiny and new”,
+  'de-DE' => "glänzend und neu"
+})
+```
+
+Deliver will use "Shiny and new" for en-US, el and it.
+
+It will use "glänzend und neu" for de-DE.
+
+You can do the same with folders
+
+```
+   default
+      keywords.txt     
+      marketing_url.txt
+      name.txt
+      privacy_url.txt
+      support_url.txt
+      release_notes.txt
+   en-US
+      description.txt
+   de-DE
+      description.txt
+   el
+      description.txt
+   it
+      description.txt
+```
+
+In this case, default values for keywords, urls, name and release notes are used in all localisations, but each language has a fully localised description
+
+
+
 ## Automatically create screenshots
 
 If you want to integrate `deliver` with [snapshot](https://github.com/fastlane/snapshot), check out [fastlane](https://fastlane.tools)!

--- a/lib/deliver/loader.rb
+++ b/lib/deliver/loader.rb
@@ -4,8 +4,9 @@ module Deliver
   module Loader
     # The directory 'appleTV' is a special folder that will cause our screenshot gathering code to iterate
     # through it as well searching for language folders.
-    APPLE_TV_DIR_NAME = "appleTV"
-    ALL_LANGUAGES = (FastlaneCore::Languages::ALL_LANGUAGES + [APPLE_TV_DIR_NAME]).map(&:downcase).freeze
+    APPLE_TV_DIR_NAME = "appleTV".freeze
+    DEFAULT_DIR_NAME = "default".freeze
+    ALL_LANGUAGES = (FastlaneCore::Languages::ALL_LANGUAGES + [APPLE_TV_DIR_NAME, APPLE_TV_DIR_NAME]).map(&:downcase).freeze
 
     def self.language_folders(root)
       Dir.glob(File.join(root, '*')).select do |path|

--- a/lib/deliver/runner.rb
+++ b/lib/deliver/runner.rb
@@ -49,6 +49,7 @@ module Deliver
       # First, collect all the things for the HTML Report
       screenshots = UploadScreenshots.new.collect_screenshots(options)
       UploadMetadata.new.load_from_filesystem(options)
+      UploadMetadata.new.assign_defaults(options)
 
       # Validate
       validate_html(screenshots)


### PR DESCRIPTION
Users can specify a default which applies when there is no specific
value for a given language.

name ({
"en_us" => "English name",
"default" => "Default name"})

will have the same effect as

name ({
"en_us" => "English name",
"fr_FR" => "Default name",
"it" => "Default name",
"ja" => "Default name"})

similarly, a user can create a metadata folder 'default' and put in
something like release_notes.txt
this will be used for all languages where there isn't an explicit
release_notes.txt

languages are filled in if they are either
1) used in a setting explicitly in the deliverfile
2) there is a language folder (possibly empty) in the metadata folder
