### PR TITLE
Fixing folder creation on downloads

### DIFF
--- a/lib/deliver/commands_generator.rb
+++ b/lib/deliver/commands_generator.rb
@@ -97,7 +97,8 @@ module Deliver
           options = FastlaneCore::Configuration.create(Deliver::Options.available_options, options.__hash__)
           options.load_configuration_file("Deliverfile")
           Deliver::Runner.new(options) # to login...
-          path = options[:screenshots_path] || (FastlaneCore::Helper.fastlane_enabled? ? './fastlane' : '.')
+          containing = FastlaneCore::Helper.fastlane_enabled? ? './fastlane' : '.'
+          path = options[:screenshots_path] || File.join(containing, 'screenshots')
           Deliver::DownloadScreenshots.run(options, path)
         end
       end
@@ -110,9 +111,10 @@ module Deliver
           options = FastlaneCore::Configuration.create(Deliver::Options.available_options, options.__hash__)
           options.load_configuration_file("Deliverfile")
           Deliver::Runner.new(options) # to login...
-          path = options[:metadata_path] || (FastlaneCore::Helper.fastlane_enabled? ? './fastlane' : '.')
+          containing = FastlaneCore::Helper.fastlane_enabled? ? './fastlane' : '.'
+          path = options[:metadata_path] || File.join(containing, 'metadata')
           res = ENV["DELIVER_FORCE_OVERWRITE"]
-          res ||= UI.confirm("Do you want to overwrite existing metadata on path '#{File.expand_path(path)}/metadata'?")
+          res ||= UI.confirm("Do you want to overwrite existing metadata on path '#{File.expand_path(path)}'?")
           if res
             require 'deliver/setup'
             v = options[:app].latest_version

--- a/lib/deliver/download_screenshots.rb
+++ b/lib/deliver/download_screenshots.rb
@@ -23,9 +23,9 @@ module Deliver
           # If the screen shot is for an appleTV we need to store it in a way that we'll know it's an appleTV
           # screen shot later as the screen size is the same as an iPhone 6 Plus in landscape.
           if screenshot.device_type == "appleTV"
-            containing_folder = File.join(folder_path, "screenshots", "appleTV", screenshot.language)
+            containing_folder = File.join(folder_path, "appleTV", screenshot.language)
           else
-            containing_folder = File.join(folder_path, "screenshots", screenshot.language)
+            containing_folder = File.join(folder_path, screenshot.language)
           end
 
           begin

--- a/lib/deliver/setup.rb
+++ b/lib/deliver/setup.rb
@@ -23,7 +23,7 @@ module Deliver
     # and screenshots folders
     def generate_deliver_file(deliver_path, options)
       v = options[:app].latest_version
-      generate_metadata_files(v, deliver_path)
+      generate_metadata_files(v, File.join(deliver_path, 'metadata'))
 
       # Generate the final Deliverfile here
       gem_path = Helper.gem_path('deliver')
@@ -33,9 +33,8 @@ module Deliver
       return deliver
     end
 
-    def generate_metadata_files(v, deliver_path)
+    def generate_metadata_files(v, path)
       app_details = v.application.details
-      containing = File.join(deliver_path, 'metadata')
 
       # All the localised metadata
       (UploadMetadata::LOCALISED_VERSION_VALUES + UploadMetadata::LOCALISED_APP_VALUES).each do |key|
@@ -46,7 +45,7 @@ module Deliver
             content = app_details.send(key)[language]
           end
 
-          resulting_path = File.join(containing, language, "#{key}.txt")
+          resulting_path = File.join(path, language, "#{key}.txt")
           FileUtils.mkdir_p(File.expand_path('..', resulting_path))
           File.write(resulting_path, content)
           UI.message("Writing to '#{resulting_path}'")
@@ -61,7 +60,7 @@ module Deliver
           content = app_details.send(key)
         end
 
-        resulting_path = File.join(containing, "#{key}.txt")
+        resulting_path = File.join(path, "#{key}.txt")
         File.write(resulting_path, content)
         UI.message("Writing to '#{resulting_path}'")
       end
@@ -70,8 +69,9 @@ module Deliver
     end
 
     def download_screenshots(deliver_path, options)
-      FileUtils.mkdir_p(File.join(deliver_path, 'screenshots'))
-      Deliver::DownloadScreenshots.run(options, deliver_path)
+      path = File.join(deliver_path, 'screenshots')
+      FileUtils.mkdir_p(path)
+      Deliver::DownloadScreenshots.run(options, path)
     end
   end
 end


### PR DESCRIPTION
Download commands should not create a `screenshots` or `metadata` folder if a custom path is used, something that i missed yesterday.

If you use the options `screenshots_path` or `metadata_path` for uploading, you specify the path directly pointing to the related directory, but if you set this for downloading it creates another `screenshot`/`metadata` directory inside.

The classes/methods for uploading take a path param and use this path without appending something. The download classes now do the same and the appending of the correct subfolder happens before calling it.

I think this is now the behavior that was intended?
