### PR TITLE
Fix the default-setting feature.

### DIFF
--- a/lib/deliver/loader.rb
+++ b/lib/deliver/loader.rb
@@ -6,7 +6,7 @@ module Deliver
     # through it as well searching for language folders.
     APPLE_TV_DIR_NAME = "appleTV".freeze
     DEFAULT_DIR_NAME = "default".freeze
-    ALL_LANGUAGES = (FastlaneCore::Languages::ALL_LANGUAGES + [APPLE_TV_DIR_NAME, APPLE_TV_DIR_NAME]).map(&:downcase).freeze
+    ALL_LANGUAGES = (FastlaneCore::Languages::ALL_LANGUAGES + [APPLE_TV_DIR_NAME, APPLE_TV_DIR_NAME, DEFAULT_DIR_NAME]).map(&:downcase).freeze
 
     def self.language_folders(root)
       Dir.glob(File.join(root, '*')).select do |path|


### PR DESCRIPTION
This is required for upload_metadata/load_from_filesystem to correctly load default values from the default folder.

My apologies; I should have spotted that this was missing in the tidied version of my original request.
